### PR TITLE
Fix PathBuf parsing in structopt

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use tq::ast::Filter;
 struct Opt {
     #[structopt(default_value = ".", parse(from_str = "filter_or_default"))]
     pub filter: String,
-    #[structopt(default_value = "Vec::new")]
+    #[structopt(parse(from_os_str))]
     pub files: Vec<PathBuf>,
 }
 


### PR DESCRIPTION
### Fixed

* Switch from using the `FromStr` implementation for `PathBuf` to `parse(from_os_str)` in `structopt` instead. This should hopefully get `tq` to build properly in CircleCI.

Closes #15.