### PR TITLE
Disallow keywords in identifier paths and function names

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -41,10 +41,10 @@ impl FromStr for Module {
 
 pub fn parse_module<S: AsRef<str>>(module: S) -> Result<Module, ModuleError> {
     let text = module.as_ref();
-    let metadata = (seq(b"module") + tokens::space()) * expr() - tokens::space() - sym(b';');
+    let meta = (tokens::keyword_module() + tokens::space()) * expr() - tokens::space() - sym(b';');
     let stmts = (stmt() - tokens::space()).repeat(0..);
     let decls = (function_decl() - tokens::space()).repeat(1..);
-    (metadata.opt() + stmts + decls - end())
+    (meta.opt() + stmts + decls - end())
         .map(|((meta, stmts), decls)| Module::new(meta, stmts, decls))
         .parse(text.as_bytes())
         .map_err(|e| ModuleError::new(e, text))

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -93,8 +93,8 @@ fn assign_op<'a>() -> Parser<'a, u8, Expr> {
 }
 
 fn logical<'a>() -> Parser<'a, u8, Expr> {
-    let and = seq(b"and").map(|_| BinaryOp::And);
-    let or = seq(b"or").map(|_| BinaryOp::Or);
+    let and = tokens::keyword_and().map(|_| BinaryOp::And);
+    let or = tokens::keyword_or().map(|_| BinaryOp::Or);
     let expr = call(compare) + ((and | or) + call(compare)).repeat(0..);
     expr.map(|(first, rest)| {
         rest.into_iter().fold(first, |lhs, (op, rhs)| {
@@ -180,7 +180,7 @@ fn terms<'a>() -> Parser<'a, u8, Expr> {
     let paren = sym(b'(') * call(expr).map(Box::from).map(Expr::Paren) - sym(b')');
     let control_flow = control_flow();
     let label_break = label_break().map(Expr::Break);
-    let empty = seq(b"empty").map(|_| Expr::Empty);
+    let empty = tokens::keyword_empty().map(|_| Expr::Empty);
     let fn_call = function_call().map(Expr::FnCall);
     let filter = filter();
     let construct = construct();

--- a/src/parser/expr/function.rs
+++ b/src/parser/expr/function.rs
@@ -6,7 +6,7 @@ use super::{expr, tokens};
 use crate::ast::{ExprFnCall, ExprFnDecl};
 
 pub fn function_decl<'a>() -> Parser<'a, u8, ExprFnDecl> {
-    let name = tokens::space() * (seq(b"def ") * tokens::ident_path());
+    let name = (tokens::space() + tokens::keyword_def() + tokens::space()) * tokens::ident_path();
     let param = || tokens::space() * tokens::fn_param() - tokens::space();
     let params = optional_arg_sequence(param) - sym(b':');
     let body = call(expr) - sym(b';');

--- a/src/parser/expr/label.rs
+++ b/src/parser/expr/label.rs
@@ -4,14 +4,14 @@ use super::tokens;
 use crate::ast::tokens::Label;
 
 pub fn label_decl<'a>() -> Parser<'a, u8, Label> {
-    let keyword = seq(b"label") + tokens::space();
+    let keyword = tokens::keyword_label() + tokens::space();
     let name = tokens::variable() - tokens::space();
     let label = (keyword * name).map(Label::from);
     tokens::space() * label - tokens::space()
 }
 
 pub fn label_break<'a>() -> Parser<'a, u8, Label> {
-    let keyword = seq(b"break") + tokens::space();
+    let keyword = tokens::keyword_break() + tokens::space();
     let name = tokens::variable();
     (keyword * name).map(Label::from)
 }

--- a/src/parser/expr/pattern.rs
+++ b/src/parser/expr/pattern.rs
@@ -22,7 +22,7 @@ fn table<'a>() -> Parser<'a, u8, ExprPattern> {
 }
 
 pub fn binding<'a>() -> Parser<'a, u8, ExprBinding> {
-    let bind = call(unary) + (seq(b"as") * call(pattern));
+    let bind = call(unary) + (tokens::keyword_as() * call(pattern));
     bind.map(|(expr, pat)| ExprBinding::new(expr, pat))
 }
 

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -15,8 +15,8 @@ pub fn stmt<'a>() -> Parser<'a, u8, Stmt> {
 }
 
 fn import_toml<'a>() -> Parser<'a, u8, StmtImportToml> {
-    let keyword = seq(b"import") + tokens::space();
-    let file = path_buf() - tokens::space() - seq(b"as") - tokens::space();
+    let keyword = tokens::keyword_import() + tokens::space();
+    let file = path_buf() - tokens::space() - tokens::keyword_as() - tokens::space();
     let var = tokens::variable() - tokens::space();
     let metadata = expr().opt();
     let stmt = keyword * (file + var + metadata);
@@ -24,8 +24,8 @@ fn import_toml<'a>() -> Parser<'a, u8, StmtImportToml> {
 }
 
 fn import_mod<'a>() -> Parser<'a, u8, StmtImportMod> {
-    let keyword = seq(b"import") + tokens::space();
-    let file = path_buf() - tokens::space() - seq(b"as") - tokens::space();
+    let keyword = tokens::keyword_import() + tokens::space();
+    let file = path_buf() - tokens::space() - tokens::keyword_as() - tokens::space();
     let path = tokens::ident_path() - tokens::space();
     let metadata = expr().opt();
     let stmt = keyword * (file + path + metadata);
@@ -33,7 +33,7 @@ fn import_mod<'a>() -> Parser<'a, u8, StmtImportMod> {
 }
 
 fn include<'a>() -> Parser<'a, u8, StmtInclude> {
-    let keyword = seq(b"include") + tokens::space();
+    let keyword = tokens::keyword_include() + tokens::space();
     let file = path_buf() - tokens::space();
     let metadata = expr().opt();
     let stmt = keyword * (file + metadata);

--- a/src/parser/tokens.rs
+++ b/src/parser/tokens.rs
@@ -1,3 +1,4 @@
+pub use self::keywords::*;
 pub use self::literal::{literal, string};
 
 use std::iter;
@@ -7,6 +8,7 @@ use pom::parser::*;
 
 use crate::ast::tokens::{FnParam, Ident, IdentPath, Variable};
 
+mod keywords;
 mod literal;
 
 pub fn space<'a>() -> Parser<'a, u8, ()> {
@@ -23,9 +25,11 @@ pub fn identifier<'a>() -> Parser<'a, u8, Ident> {
 }
 
 pub fn ident_path<'a>() -> Parser<'a, u8, IdentPath> {
-    (identifier() + (seq(b"::") * identifier()).repeat(0..))
-        .map(|(first, rest)| iter::once(first).chain(rest))
-        .map(IdentPath::from)
+    let single = !keyword() * identifier().repeat(1);
+    let multiple = (identifier() + (seq(b"::") * identifier()).repeat(1..))
+        .map(|(first, rest)| iter::once(first).chain(rest).collect());
+
+    (single | multiple).map(IdentPath::from)
 }
 
 pub fn variable<'a>() -> Parser<'a, u8, Variable> {

--- a/src/parser/tokens/keywords.rs
+++ b/src/parser/tokens/keywords.rs
@@ -1,0 +1,36 @@
+use pom::parser::*;
+
+macro_rules! define_keywords {
+    ($($function:ident => $keyword:tt),+) => {
+        pub fn keyword<'a>() -> Parser<'a, u8, &'a [u8]> {
+            $($function())|+
+        }
+
+        $(
+            pub fn $function<'a>() -> Parser<'a, u8, &'a [u8]> {
+                seq(stringify!($keyword).as_bytes())
+            }
+        )+
+    };
+}
+
+define_keywords! {
+    keyword_and => and,
+    keyword_as => as,
+    keyword_break => break,
+    keyword_catch => catch,
+    keyword_def => def,
+    keyword_elif => elif,
+    keyword_end => end,
+    keyword_empty => empty,
+    keyword_foreach => foreach,
+    keyword_if => if,
+    keyword_import => import,
+    keyword_include => include,
+    keyword_label => label,
+    keyword_module => module,
+    keyword_or => or,
+    keyword_reduce => reduce,
+    keyword_then => then,
+    keyword_try => try
+}


### PR DESCRIPTION
### Added

* Add `parser::tokens::keywords` module with parsers for reserved keywords.

### Changed

* Disallow reserved keywords in identifier paths and function names.
* Use `parser::tokens::keywords` functions for parsing keywords instead of `seq()` calls.

Fixes #20.