### PR TITLE
Fix some keyword parsing issues

### DIFF
--- a/src/parser/expr/control_flow.rs
+++ b/src/parser/expr/control_flow.rs
@@ -20,11 +20,11 @@ fn foreach<'a>() -> Parser<'a, u8, Expr> {
 }
 
 fn if_else<'a>() -> Parser<'a, u8, Expr> {
-    use super::tokens::{keyword_elif, keyword_end, keyword_if, keyword_then};
+    use super::tokens::{keyword_elif, keyword_else, keyword_end, keyword_if, keyword_then};
 
     let main_clause = keyword_if() * call(expr) + (keyword_then() * call(expr));
     let alt_clauses = (keyword_elif() * call(expr) + (keyword_then() * call(expr))).repeat(0..);
-    let fallback = keyword_end() * call(expr) - keyword_end();
+    let fallback = keyword_else() * call(expr) - keyword_end();
 
     (main_clause + alt_clauses + fallback)
         .map(|((main, alt), f)| ExprIfElse::new(main, alt, f))

--- a/src/parser/tokens/keywords.rs
+++ b/src/parser/tokens/keywords.rs
@@ -1,9 +1,10 @@
+use pom::char_class::alphanum;
 use pom::parser::*;
 
 macro_rules! define_keywords {
     ($($function:ident => $keyword:tt),+) => {
         pub fn keyword<'a>() -> Parser<'a, u8, &'a [u8]> {
-            $($function())|+
+            ($($function())|+) - not_a(alphanum)
         }
 
         $(

--- a/src/parser/tokens/keywords.rs
+++ b/src/parser/tokens/keywords.rs
@@ -22,6 +22,7 @@ define_keywords! {
     keyword_catch => catch,
     keyword_def => def,
     keyword_elif => elif,
+    keyword_else => else,
     keyword_end => end,
     keyword_empty => empty,
     keyword_foreach => foreach,


### PR DESCRIPTION
### Added

* Add missing reserved keyword `else`.

### Fixed

* Match against the entire word when checking for keywords.
* Fix if-else expression parser.

This is a follow-up PR to #22.