### PR TITLE
Remove unused statements from builtin.tq

### DIFF
--- a/builtin.tq
+++ b/builtin.tq
@@ -1,7 +1,3 @@
-module "blah";
-
-import "hi" as BLAH;
-
 def halt_error: halt_error(5);
 def error(msg): msg|error;
 def map(f): [.[] | f];


### PR DESCRIPTION
### Removed

* Remove unused `module` and `import` statements from `builtin.tq`.

Fixes #12.