### PR TITLE
Enable LTO and improve parser performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ toml = "0.5.1"
 
 [dev-dependencies]
 float-cmp = "0.4"
+
+[profile.release]
+lto = true

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -17,26 +17,26 @@ pub fn stmt<'a>() -> Parser<'a, u8, Stmt> {
 fn import_toml<'a>() -> Parser<'a, u8, StmtImportToml> {
     let keyword = tokens::keyword_import() + tokens::space();
     let file = path_buf() - tokens::space() - tokens::keyword_as() - tokens::space();
-    let var = tokens::variable() - tokens::space();
+    let var = tokens::variable();
     let metadata = expr().opt();
-    let stmt = keyword * (file + var + metadata);
+    let stmt = keyword * file + var + metadata;
     stmt.map(|((file, var), meta)| StmtImportToml::new(file, var, meta))
 }
 
 fn import_mod<'a>() -> Parser<'a, u8, StmtImportMod> {
     let keyword = tokens::keyword_import() + tokens::space();
     let file = path_buf() - tokens::space() - tokens::keyword_as() - tokens::space();
-    let path = tokens::ident_path() - tokens::space();
+    let path = tokens::ident_path();
     let metadata = expr().opt();
-    let stmt = keyword * (file + path + metadata);
+    let stmt = keyword * file + path + metadata;
     stmt.map(|((file, path), meta)| StmtImportMod::new(file, path, meta))
 }
 
 fn include<'a>() -> Parser<'a, u8, StmtInclude> {
     let keyword = tokens::keyword_include() + tokens::space();
-    let file = path_buf() - tokens::space();
+    let file = path_buf();
     let metadata = expr().opt();
-    let stmt = keyword * (file + metadata);
+    let stmt = keyword * file + metadata;
     stmt.map(|(file, meta)| StmtInclude::new(file, meta))
 }
 

--- a/src/parser/tokens.rs
+++ b/src/parser/tokens.rs
@@ -12,8 +12,8 @@ mod keywords;
 mod literal;
 
 pub fn space<'a>() -> Parser<'a, u8, ()> {
-    let comment = (sym(b'#') + none_of(b"\n\r").repeat(0..)).collect();
-    let whitespace = is_a(multispace).collect();
+    let comment = sym(b'#') - none_of(b"\n\r").repeat(0..);
+    let whitespace = is_a(multispace);
     (comment | whitespace).repeat(0..).discard()
 }
 


### PR DESCRIPTION
### Changed

* Enable LTO for release builds.
* Eliminate unnecessary parentheses in complex parser expressions.
* Remove unnecessary parser `map()` calls and operate on values directly where possible.
* Call `map()` directly on `call(expr)` rather than on parenthesized compound expression.
* Eliminate wasteful collect in `parser::tokens::space()`.

This PR has slightly improved the speeds in parsing `builtin.tq` compared to `master`:

#### Before

```
real    0m1.508s~0m1.551s
user    0m1.496s~0m1.562s
sys     0m0.005s~0m0.014s
```

### After

```
real    0m1.458s~0m1.477s
user    0m1.449s~0m1.455s
sys     0m0.005s~0m0.009s
```