### PR TITLE
Fix regression in identifier path parser

### DIFF
--- a/src/parser/tokens.rs
+++ b/src/parser/tokens.rs
@@ -27,7 +27,7 @@ pub fn identifier<'a>() -> Parser<'a, u8, Ident> {
 }
 
 pub fn ident_path<'a>() -> Parser<'a, u8, IdentPath> {
-    let single = !keyword() * identifier().repeat(1);
+    let single = !keyword() * identifier().repeat(1) - !seq(b"::");
     let multiple = (identifier() + (seq(b"::") * identifier()).repeat(1..))
         .map(|(first, rest)| iter::once(first).chain(rest).collect());
 

--- a/src/parser/tokens.rs
+++ b/src/parser/tokens.rs
@@ -27,7 +27,7 @@ pub fn identifier<'a>() -> Parser<'a, u8, Ident> {
 }
 
 pub fn ident_path<'a>() -> Parser<'a, u8, IdentPath> {
-    let single = !keyword() * identifier().repeat(1) - !seq(b"::");
+    let single = !keyword() * (identifier() - !seq(b"::")).repeat(1);
     let multiple = (identifier() + (seq(b"::") * identifier()).repeat(1..))
         .map(|(first, rest)| iter::once(first).chain(rest).collect());
 

--- a/src/parser/tokens/keywords.rs
+++ b/src/parser/tokens/keywords.rs
@@ -4,7 +4,7 @@ use pom::parser::*;
 macro_rules! define_keywords {
     ($($function:ident => $keyword:tt),+) => {
         pub fn keyword<'a>() -> Parser<'a, u8, &'a [u8]> {
-            ($($function())|+) - not_a(alphanum)
+            ($($function())|+) - -not_a(alphanum)
         }
 
         $(


### PR DESCRIPTION
### Fixed

* Ensure _all_ segments of the `IdentPath` are parsed.
* Do not consume next non-alphanumeric character when parsing keywords.

This PR should fix a regression caused by #22 where only the `single` case was being hit and no filters ever reached the `multiple` case, meaning it could parse `foo` but not `foo::bar`. And since module paths is the main point of the `IdentPath` AST type, not being able to parse a sequence identifiers is kind of a deal-breaker. The `ident_path()` function now checks whether or not the `single` case is followed by a `::` separator, and switches to the `multiple` case if it is.

Thankfully, the fix doesn't impact parsing speed too drastically, as seen in the Criterion benchmark results below:

```
parse builtin.tq        time:   [1.4264 s 1.4277 s 1.4289 s]
                        change: [-0.8395% -0.5240% -0.1650%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
```