### PR TITLE
Refine statement parser

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -9,50 +9,65 @@ mod macros;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Filter {
-    stmts: Vec<Stmt>,
+    stmts: Stmts,
     expr: Expr,
 }
 
 impl Filter {
-    pub fn new(stmts: Vec<Stmt>, expr: Expr) -> Self {
+    pub fn new(stmts: Stmts, expr: Expr) -> Self {
         Filter { stmts, expr }
     }
 }
 
 impl Display for Filter {
     fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
-        let stmts: String = self.stmts.iter().map(|s| format!("{} ", s)).collect();
-        write!(fmt, "{}{}", stmts, self.expr)
+        write!(fmt, "{}{}", self.stmts, self.expr)
     }
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Module {
-    metadata: Option<Expr>,
-    stmts: Vec<Stmt>,
+    stmts: Stmts,
     decls: Vec<ExprFnDecl>,
 }
 
 impl Module {
-    pub fn new(metadata: Option<Expr>, stmts: Vec<Stmt>, decls: Vec<ExprFnDecl>) -> Self {
-        Module {
-            metadata,
-            stmts,
-            decls,
-        }
+    pub fn new(stmts: Stmts, decls: Vec<ExprFnDecl>) -> Self {
+        Module { stmts, decls }
     }
 }
 
 impl Display for Module {
     fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
-        let meta = self
-            .metadata
-            .as_ref()
-            .map(|e| format!("module {};\n", e))
-            .unwrap_or_default();
+        let strs: Vec<_> = self.decls.iter().map(ToString::to_string).collect();
+        let decls = strs.join("\n");
+        write!(fmt, "{}{}", self.stmts.to_string_pretty(), decls)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Stmts {
+    module: Option<Expr>,
+    stmts: Vec<Stmt>,
+}
+
+impl Stmts {
+    pub fn new(module: Option<Expr>, stmts: Vec<Stmt>) -> Self {
+        Stmts { module, stmts }
+    }
+
+    fn to_string_pretty(&self) -> String {
+        let module = self.module.as_ref().map(|m| format!("module {};\n", m));
         let stmts: String = self.stmts.iter().map(|s| format!("{}\n", s)).collect();
-        let decls: String = self.decls.iter().map(|d| format!("{}\n", d)).collect();
-        write!(fmt, "{}{}{}", meta, stmts, decls)
+        format!("{}{}", module.unwrap_or_default(), stmts)
+    }
+}
+
+impl Display for Stmts {
+    fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
+        let module = self.module.as_ref().map(|m| format!("module {}; ", m));
+        let stmts: String = self.stmts.iter().map(|s| format!("{} ", s)).collect();
+        write!(fmt, "{}{}", module.unwrap_or_default(), stmts)
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@ use std::str::{self, FromStr};
 use pom::parser::*;
 
 use self::expr::{expr, function_decl};
-use self::stmt::stmt;
+use self::stmt::stmts;
 use crate::ast::{Filter, Module};
 
 mod error;
@@ -23,9 +23,7 @@ impl FromStr for Filter {
 
 pub fn parse_filter<S: AsRef<str>>(filter: S) -> Result<Filter, FilterError> {
     let text = filter.as_ref();
-    let stmts = stmt().repeat(0..);
-    let expr = expr();
-    (stmts + expr - end())
+    (tokens::space() * stmts() + expr() - end())
         .map(|(stmts, expr)| Filter::new(stmts, expr))
         .parse(text.as_bytes())
         .map_err(|e| FilterError::new(e, text))
@@ -41,11 +39,9 @@ impl FromStr for Module {
 
 pub fn parse_module<S: AsRef<str>>(module: S) -> Result<Module, ModuleError> {
     let text = module.as_ref();
-    let meta = (tokens::space() + tokens::keyword_module()) * expr() - sym(b';');
-    let stmts = stmt().repeat(0..);
     let decls = function_decl().repeat(0..);
-    (meta.opt() + stmts + decls - tokens::space() - end())
-        .map(|((meta, stmts), decls)| Module::new(meta, stmts, decls))
+    (tokens::space() * stmts() + decls - tokens::space() - end())
+        .map(|(stmts, decls)| Module::new(stmts, decls))
         .parse(text.as_bytes())
         .map_err(|e| ModuleError::new(e, text))
 }


### PR DESCRIPTION
### Added

* Write `tq_stmts!()` and `tq_stmts_and_str!()` macros for testing .
* Add `parser::stmt` unit tests using the macros.

### Changed

* Wrap optional module statement and import statements into a single `Stmts` type.
* Allow `module` keyword in filters, not just modules.
* Update `Display` implementation for `Filter` to display `module` statement inline, rather than formatted with newlines.

The way this parser handles whitespace around expressions is somewhat complex and inconsistent. Ideally, the model should be simplified to:

```
stmts = { ... } - tokens::space()
expr = { ... } - tokens::space()
filter = tokens::space() * stmts + expr - end()
```
```
stmts = { ... } - tokens::space()
decls = (function_decl() - tokens::space()).repeat(0..)
module = tokens::space() * stmts + decls - end()
```

These changes are out of scope for this particular PR, but it is a good first step in the right direction.