### PR TITLE
Fix folding order in parser

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -210,9 +210,9 @@ pub enum Expr {
     /// `{ foo = 1, bar = 2 }[]`
     Index(Box<Expr>, Box<ExprIndex>),
 
-    /// `.package as $pkg`
-    /// `.package as { name = $name, authors = $authors }`
-    Binding(Box<ExprBinding>),
+    /// `.package as $pkg | ...`
+    /// `.package as { name = $name, authors = $authors } | ...`
+    Binding(Box<ExprBinding>, Box<Expr>),
 
     /// `def increment: . + 1;`
     /// `def addvalue(f): f as $f | map(. + $f);`
@@ -268,7 +268,7 @@ impl Display for Expr {
 
             Expr::Filter(ref filter) => write!(fmt, "{}", filter),
             Expr::Index(ref expr, ref index) => write!(fmt, "{}{}", expr, index),
-            Expr::Binding(ref binding) => write!(fmt, "{}", binding),
+            Expr::Binding(ref binding, ref expr) => write!(fmt, "{} | {}", binding, expr),
 
             Expr::FnDecl(ref decl, ref expr) => write!(fmt, "{} {}", decl, expr),
             Expr::FnCall(ref call) => write!(fmt, "{}", call),

--- a/src/ast/macros.rs
+++ b/src/ast/macros.rs
@@ -412,22 +412,19 @@ macro_rules! pipe {
     (@rule ($($expr:tt)+) as [ $($pat:tt)+ ] | $($rest:tt)+) => {{
         let pat = $crate::tq_pattern!([ $($pat)+ ]);
         let bind = ExprBinding::new($crate::term!($($expr)+), pat);
-        let expr = Expr::Binding(Box::new(bind));
-        Expr::Binary(BinaryOp::Pipe, Box::new(expr), Box::new($crate::pipe!($($rest)+)))
+        Expr::Binding(Box::new(bind), Box::new($crate::pipe!($($rest)+)))
     }};
 
     (@rule ($($expr:tt)+) as { $($pat:tt)+ } | $($rest:tt)+) => {{
         let pat = $crate::tq_pattern!({ $($pat)+ });
         let bind = ExprBinding::new($crate::term!($($expr)+), pat);
-        let expr = Expr::Binding(Box::new(bind));
-        Expr::Binary(BinaryOp::Pipe, Box::new(expr), Box::new($crate::pipe!($($rest)+)))
+        Expr::Binding(Box::new(bind), Box::new($crate::pipe!($($rest)+)))
     }};
 
     (@rule ($($expr:tt)+) as $dollar:tt $var:ident | $($rest:tt)+) => {{
         let pat = $crate::tq_pattern!($dollar$var);
         let bind = ExprBinding::new($crate::term!($($expr)+), pat);
-        let expr = Expr::Binding(Box::new(bind));
-        Expr::Binary(BinaryOp::Pipe, Box::new(expr), Box::new($crate::pipe!($($rest)+)))
+        Expr::Binding(Box::new(bind), Box::new($crate::pipe!($($rest)+)))
     }};
 
     (@rule ($($lhs:tt)+) | $($rhs:tt)+) => {{

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -60,12 +60,11 @@ fn fn_decl(input: &str) -> IResult<&str, Expr> {
 }
 
 fn binding(input: &str) -> IResult<&str, Expr> {
-    let binding = map(pattern::binding, |b| Expr::Binding(Box::new(b)));
-    let binding = terminated(binding, tuple((tokens::space, char('|'), tokens::space)));
-    let expr = pair(many0(binding), label);
+    let pipe = tuple((tokens::space, char('|'), tokens::space));
+    let expr = pair(many0(terminated(pattern::binding, pipe)), label);
     map(expr, |(bindings, expr)| {
         bindings.into_iter().rev().fold(expr, |expr, binding| {
-            Expr::Binary(BinaryOp::Pipe, Box::new(binding), Box::new(expr))
+            Expr::Binding(Box::new(binding), Box::new(expr))
         })
     })(input)
 }

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -53,7 +53,7 @@ fn chain(input: &str) -> IResult<&str, Expr> {
 fn fn_decl(input: &str) -> IResult<&str, Expr> {
     let expr = pair(many0(terminated(function_decl, tokens::space)), binding);
     map(expr, |(decls, expr)| {
-        decls.into_iter().fold(expr, |expr, decl| {
+        decls.into_iter().rev().fold(expr, |expr, decl| {
             Expr::FnDecl(Box::new(decl), Box::new(expr))
         })
     })(input)
@@ -64,7 +64,7 @@ fn binding(input: &str) -> IResult<&str, Expr> {
     let binding = terminated(binding, tuple((tokens::space, char('|'), tokens::space)));
     let expr = pair(many0(binding), label);
     map(expr, |(bindings, expr)| {
-        bindings.into_iter().fold(expr, |expr, binding| {
+        bindings.into_iter().rev().fold(expr, |expr, binding| {
             Expr::Binary(BinaryOp::Pipe, Box::new(binding), Box::new(expr))
         })
     })(input)
@@ -75,7 +75,7 @@ fn label(input: &str) -> IResult<&str, Expr> {
     let label = terminated(label, tuple((tokens::space, char('|'), tokens::space)));
     let expr = pair(many0(label), assign);
     map(expr, |(decls, expr)| {
-        decls.into_iter().fold(expr, |expr, label| {
+        decls.into_iter().rev().fold(expr, |expr, label| {
             Expr::Binary(BinaryOp::Pipe, Box::new(label), Box::new(expr))
         })
     })(input)

--- a/src/parser/expr/pattern.rs
+++ b/src/parser/expr/pattern.rs
@@ -57,11 +57,8 @@ mod tests {
         ($($expr:tt)*) => {{
             let (expr, string) = $crate::tq_expr_and_str!($($expr)+ | .);
             match expr {
-                $crate::ast::Expr::Binary(_, lhs, _) => match *lhs {
-                    $crate::ast::Expr::Binding(bind) => (*bind, string.replace(" | .", "")),
-                    e => panic!(format!("tq_expr_and_str!() did not produce an `ExprBinding`: {:?}", e)),
-                }
-                _ => panic!("tq_expr_and_str!() did not produce an `Expr::Binary`"),
+                $crate::ast::Expr::Binding(bind, _) => (*bind, string.replace(" | .", "")),
+                e => panic!(format!("tq_expr_and_str!() did not produce an `Expr::Binding`: {:?}", e)),
             }
         }};
     }


### PR DESCRIPTION
### Changed

* Change bindings to have their own scope instead of overloading the pipe operator.

### Fixed

* Reverse fold over function declarations, bindings, and labels.

Fixes #36.