### PR TITLE
Improve macro support for function declarations and calls

### DIFF
--- a/src/ast/macros.rs
+++ b/src/ast/macros.rs
@@ -401,7 +401,11 @@ macro_rules! tq_token {
         $crate::ast::tokens::Ident::from(stringify!($ident))
     };
 
-    ( $(::)? $($path:ident)::+ ) => {
+    ( $($path:ident)::+ ) => {
+        $crate::ast::tokens::IdentPath::from(vec![$(stringify!($path)),*])
+    };
+
+    ( ::$($path:ident)::+ ) => {
         $crate::ast::tokens::IdentPath::from(vec![$(stringify!($path)),*])
     };
 

--- a/src/ast/macros.rs
+++ b/src/ast/macros.rs
@@ -120,9 +120,7 @@ macro_rules! tq_stmts {
     };
 
     (@stmt import $file:tt as $($path:ident)::+ ; $($rest:tt)*) => {{
-        let path = IdentPath::from(vec![$(stringify!($path)),+]);
-        let stmt = StmtImportMod::new($file.into(), path, None);
-
+        let stmt = StmtImportMod::new($file.into(), $crate::tq_token!(::$($path)::+), None);
         let first = ::std::iter::once(Stmt::ImportMod(stmt));
         let rest = $crate::tq_stmts!(@stmt $($rest)*);
         first.chain(rest)
@@ -130,9 +128,7 @@ macro_rules! tq_stmts {
 
     (@stmt import $file:tt as $($path:ident)::+ $meta:tt ; $($rest:tt)*) => {{
         let module = Some($crate::tq_expr!($meta));
-        let path = IdentPath::from(vec![$(stringify!($path)),+]);
-        let stmt = StmtImportMod::new($file.into(), path, module);
-
+        let stmt = StmtImportMod::new($file.into(), $crate::tq_token!(::$($path)::+), module);
         let first = ::std::iter::once(Stmt::ImportMod(stmt));
         let rest = $crate::tq_stmts!(@stmt $($rest)*);
         first.chain(rest)
@@ -332,6 +328,58 @@ macro_rules! tq_filter {
 
 #[doc(hidden)]
 #[macro_export]
+macro_rules! tq_fn_args {
+    (@args ($($expr:tt)+) ; $($rest:tt)+) => {
+        ::std::iter::once($crate::tq_expr!($($expr)+)).chain($crate::tq_fn_args!($($rest)+))
+    };
+
+    (@args ($($expr:tt)+)) => {
+        ::std::iter::once($crate::tq_expr!($($expr)+))
+    };
+
+    (@args ($($prev:tt)*) $next:tt $($rest:tt)* ) => {
+        $crate::tq_fn_args!(@args ($($prev)* $next) $($rest)*)
+    };
+
+    ( $first:tt $($rest:tt)* ) => {{
+        #[allow(unused_imports)]
+        use $crate::ast::*;
+        #[allow(unused_imports)]
+        use $crate::ast::tokens::*;
+        $crate::tq_fn_args!(@args ($first) $($rest)*)
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! tq_fn_params {
+    (@args ($($arg:tt)+) ; $($rest:tt)+) => {
+        ::std::iter::once($crate::tq_fn_params!($($arg)+)).chain($crate::tq_fn_params!($($rest)+))
+    };
+
+    (@args ($($path:ident)::+)) => {{
+        ::std::iter::once(FnParam::Function($crate::tq_token!(::$($path)::+)))
+    }};
+
+    (@args ($($expr:tt)+)) => {
+        ::std::iter::once($crate::tq_expr!($($expr)+))
+    };
+
+    (@args ($($prev:tt)*) $next:tt $($rest:tt)* ) => {
+        $crate::tq_fn_args!(@args ($($prev)* $next) $($rest)*)
+    };
+
+    ( $first:tt $($rest:tt)* ) => {{
+        #[allow(unused_imports)]
+        use $crate::ast::*;
+        #[allow(unused_imports)]
+        use $crate::ast::tokens::*;
+        $crate::tq_fn_args!(@args ($first) $($rest)*)
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
 macro_rules! tq_token {
     ( false ) => {
         $crate::ast::tokens::Literal::Boolean(false)
@@ -351,6 +399,10 @@ macro_rules! tq_token {
 
     ( $ident:ident ) => {
         $crate::ast::tokens::Ident::from(stringify!($ident))
+    };
+
+    ( $(::)? $($path:ident)::+ ) => {
+        $crate::ast::tokens::IdentPath::from(vec![$(stringify!($path)),*])
     };
 
     ( $dollar:tt $var:ident ) => {
@@ -480,7 +532,14 @@ macro_rules! chain {
 #[macro_export]
 macro_rules! fn_decl {
     (@rule (def $($name:ident)::+) : $($rest:tt)+) => {{
-        let name = IdentPath::from(vec![$(stringify!($name)),+]);
+        let name = $crate::tq_token!(::$($name)::+);
+        let (body, expr) = $crate::fn_decl!($($rest)+);
+        Expr::FnDecl(Box::new(ExprFnDecl::new(name, Vec::new(), body)), Box::new(expr))
+    }};
+
+    (@rule (def $($name:ident)::+) ($($args:tt)+) : $($rest:tt)+) => {{
+        let name = $crate::tq_token!(::$($name)::+);
+        let args = $crate::tq_fn_params!($($args)+).collect();
         let (body, expr) = $crate::fn_decl!($($rest)+);
         Expr::FnDecl(Box::new(ExprFnDecl::new(name, Vec::new(), body)), Box::new(expr))
     }};
@@ -636,35 +695,50 @@ macro_rules! unary {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! term {
-    (@rule (($($expr:tt)+))) => {{
+    (($($expr:tt)+)) => {{
         Expr::Paren(Box::new($crate::tq_expr!($($expr)+)))
     }};
 
-    (@rule (..)) => {{
+    (..) => {{
         Expr::Filter(Box::new($crate::tq_filter!(..)))
     }};
 
-    (@rule (.$($path:tt)*)) => {{
+    (.$($path:tt)*) => {{
         Expr::Filter(Box::new($crate::tq_filter!(.$($path)*)))
     }};
 
-    (@rule ($dollar:tt $var:ident)) => {{
+    ($dollar:tt $var:ident) => {{
         Expr::Variable($crate::tq_token!($dollar$var))
     }};
 
-    (@rule ($literal:tt)) => {{
-        Expr::Literal($crate::tq_token!($literal))
+    (false) => {{
+        Expr::Literal($crate::tq_token!(false))
     }};
 
-    (@rule ($($prev:tt)*) $next:tt $($rest:tt)* ) => {
-        $crate::term!(@rule ($($prev)* $next) $($rest)*)
-    };
+    (true) => {{
+        Expr::Literal($crate::tq_token!(true))
+    }};
 
-    ( $first:tt $($rest:tt)* ) => {{
-        #[allow(unused_imports)]
-        use $crate::ast::*;
-        #[allow(unused_imports)]
-        use $crate::ast::tokens::*;
-        $crate::term!(@rule ($first) $($rest)*)
+    (inf) => {{
+        Expr::Literal($crate::tq_token!(inf))
+    }};
+
+    (nan) => {{
+        Expr::Literal($crate::tq_token!(nan))
+    }};
+
+    ($($fn_call:ident)::+) => {{
+        let path = $crate::tq_token!(::$($fn_call)::+);
+        Expr::FnCall(ExprFnCall::new(path, Vec::new()))
+    }};
+
+    ($($fn_call:ident)::+ ($($args:tt)+)) => {{
+        let path = $crate::tq_token!(::$($fn_call)::+);
+        let args = $crate::tq_fn_args!($($args)+).collect();
+        Expr::FnCall(ExprFnCall::new(path, args))
+    }};
+
+    ($literal:expr) => {{
+        Expr::Literal($crate::tq_token!($literal))
     }};
 }

--- a/src/parser/expr/function.rs
+++ b/src/parser/expr/function.rs
@@ -28,14 +28,13 @@ pub fn function_call(input: &str) -> IResult<&str, ExprFnCall> {
 fn opt_param_sequence(input: &str) -> IResult<&str, Vec<FnParam>> {
     let param = delimited(tokens::space, tokens::fn_param, tokens::space);
     let params = separated_nonempty_list(char(';'), param);
-    let seq = delimited(pair(tokens::space, char('(')), params, char(')'));
+    let seq = delimited(char('('), params, char(')'));
     map(opt(seq), Option::unwrap_or_default)(input)
 }
 
 fn opt_arg_sequence(input: &str) -> IResult<&str, Vec<Expr>> {
     let args = separated_nonempty_list(pair(char(';'), tokens::space), expr);
-    let open = tuple((tokens::space, char('('), tokens::space));
-    let seq = delimited(open, args, char(')'));
+    let seq = delimited(pair(char('('), tokens::space), args, char(')'));
     map(opt(seq), Option::unwrap_or_default)(input)
 }
 

--- a/src/parser/expr/function.rs
+++ b/src/parser/expr/function.rs
@@ -10,7 +10,7 @@ use crate::ast::{Expr, ExprFnCall, ExprFnDecl};
 
 pub fn function_decl(input: &str) -> IResult<&str, ExprFnDecl> {
     let key_def = pair(tokens::keyword_def, tokens::space);
-    let name = preceded(key_def, tokens::ident_path);
+    let name = delimited(key_def, tokens::ident_path, tokens::space);
     let params = terminated(opt_param_sequence, pair(char(':'), tokens::space));
     let body = terminated(expr, char(';'));
 
@@ -20,19 +20,91 @@ pub fn function_decl(input: &str) -> IResult<&str, ExprFnDecl> {
 }
 
 pub fn function_call(input: &str) -> IResult<&str, ExprFnCall> {
-    let call = pair(tokens::ident_path, opt_arg_sequence);
+    let args = preceded(tokens::space, opt_arg_sequence);
+    let call = pair(tokens::ident_path, args);
     map(call, |(name, args)| ExprFnCall::new(name, args))(input)
 }
 
 fn opt_param_sequence(input: &str) -> IResult<&str, Vec<FnParam>> {
-    let param = terminated(tokens::fn_param, tokens::space);
-    let params = separated_nonempty_list(pair(char(';'), tokens::space), param);
-    let seq = delimited(pair(char('('), tokens::space), params, char(')'));
+    let param = delimited(tokens::space, tokens::fn_param, tokens::space);
+    let params = separated_nonempty_list(char(';'), param);
+    let open = pair(tokens::space, char('('));
+    let seq = delimited(open, params, pair(char(')'), tokens::space));
     map(opt(seq), Option::unwrap_or_default)(input)
 }
 
 fn opt_arg_sequence(input: &str) -> IResult<&str, Vec<Expr>> {
     let args = separated_nonempty_list(pair(char(';'), tokens::space), expr);
-    let seq = delimited(pair(char('('), tokens::space), args, char(')'));
+    let open = tuple((tokens::space, char('('), tokens::space));
+    let seq = delimited(open, args, pair(char(')'), tokens::space));
     map(opt(seq), Option::unwrap_or_default)(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use nom::combinator::all_consuming;
+
+    use super::*;
+
+    macro_rules! tq_fn_call_and_str {
+        ($($expr:tt)+) => {{
+            let (expr, string) = $crate::tq_expr_and_str!($($expr)+);
+            match expr {
+                $crate::ast::Expr::FnCall(call) => (call, string.trim().to_string()),
+                e => panic!(format!("tq_expr_and_str!() did not produce an `ExprFnCall`: {:?}", e)),
+            }
+        }};
+    }
+
+    macro_rules! tq_fn_decl_and_str {
+        ($($expr:tt)+) => {{
+            let (expr, string) = $crate::tq_expr_and_str!($($expr)+ .);
+            match expr {
+                $crate::ast::Expr::FnDecl(decl, _) => (*decl, string.trim().trim_end_matches(" .").to_string()),
+                e => panic!(format!("tq_expr_and_str!() did not produce an `ExprFnDecl`: {:?}", e)),
+            }
+        }};
+    }
+
+    #[test]
+    fn declaration_simple() {
+        let (expected, string) = tq_fn_decl_and_str!(def foo: .;);
+        let (_, actual) = all_consuming(function_decl)(&string).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn declaration_path() {
+        let (expected, string) = tq_fn_decl_and_str!(def foo::bar: .;);
+        let (_, actual) = all_consuming(function_decl)(&string).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn declaration_with_arguments() {
+        let (expected, string) = tq_fn_decl_and_str!(def foo(first; $second): .;);
+        let (_, actual) = all_consuming(function_decl)(&string).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn call_simple() {
+        let (expected, string) = tq_fn_call_and_str!(foo);
+        let (_, actual) = all_consuming(function_call)(&string).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn call_path() {
+        let (expected, string) = tq_fn_call_and_str!(foo::bar);
+        let (_, actual) = all_consuming(function_call)(&string).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn call_with_arguments() {
+        let (expected, string) = tq_fn_call_and_str!(foo(1; 2));
+        let (_, actual) = all_consuming(function_call)(&string).unwrap();
+        assert_eq!(expected, actual);
+    }
 }

--- a/src/parser/expr/function.rs
+++ b/src/parser/expr/function.rs
@@ -28,15 +28,14 @@ pub fn function_call(input: &str) -> IResult<&str, ExprFnCall> {
 fn opt_param_sequence(input: &str) -> IResult<&str, Vec<FnParam>> {
     let param = delimited(tokens::space, tokens::fn_param, tokens::space);
     let params = separated_nonempty_list(char(';'), param);
-    let open = pair(tokens::space, char('('));
-    let seq = delimited(open, params, pair(char(')'), tokens::space));
+    let seq = delimited(pair(tokens::space, char('(')), params, char(')'));
     map(opt(seq), Option::unwrap_or_default)(input)
 }
 
 fn opt_arg_sequence(input: &str) -> IResult<&str, Vec<Expr>> {
     let args = separated_nonempty_list(pair(char(';'), tokens::space), expr);
     let open = tuple((tokens::space, char('('), tokens::space));
-    let seq = delimited(open, args, pair(char(')'), tokens::space));
+    let seq = delimited(open, args, char(')'));
     map(opt(seq), Option::unwrap_or_default)(input)
 }
 
@@ -59,8 +58,9 @@ mod tests {
     macro_rules! tq_fn_decl_and_str {
         ($($expr:tt)+) => {{
             let (expr, string) = $crate::tq_expr_and_str!($($expr)+ .);
+            let trimmed = string.trim().replace(" :", ":").trim_end_matches(" .").to_string();
             match expr {
-                $crate::ast::Expr::FnDecl(decl, _) => (*decl, string.trim().trim_end_matches(" .").to_string()),
+                $crate::ast::Expr::FnDecl(decl, _) => (*decl, trimmed),
                 e => panic!(format!("tq_expr_and_str!() did not produce an `ExprFnDecl`: {:?}", e)),
             }
         }};

--- a/src/parser/tokens/literal.rs
+++ b/src/parser/tokens/literal.rs
@@ -38,12 +38,56 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn boolean_literals() {
-        let (_, true_literal) = all_consuming(boolean)("true").unwrap();
-        assert_eq!(true_literal, true);
+    macro_rules! tq_literal_and_str {
+        ($literal:expr) => {{
+            let (expr, string) = $crate::tq_expr_and_str!($literal);
+            match expr {
+                $crate::ast::Expr::Literal(lit) => (lit, string),
+                e => panic!(format!(
+                    "tq_expr_and_str!() did not produce a `Literal`: {:?}",
+                    e
+                )),
+            }
+        }};
+    }
 
-        let (_, false_literal) = all_consuming(boolean)("false").unwrap();
-        assert_eq!(false_literal, false);
+    #[test]
+    fn boolean() {
+        let (expected, string) = tq_literal_and_str!(false);
+        let (_, actual) = all_consuming(literal)(&string).unwrap();
+        assert_eq!(expected, actual);
+
+        let (expected, string) = tq_literal_and_str!(true);
+        let (_, actual) = all_consuming(literal)(&string).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn float() {
+        let (expected, string) = tq_literal_and_str!(12.5);
+        let (_, actual) = all_consuming(literal)(&string).unwrap();
+        assert_eq!(expected, actual);
+
+        let (expected, string) = tq_literal_and_str!(12E6);
+        let (_, actual) = all_consuming(literal)(&string).unwrap();
+        assert_eq!(expected, actual);
+
+        let (expected, string) = tq_literal_and_str!(12.5E6);
+        let (_, actual) = all_consuming(literal)(&string).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn integer() {
+        let (expected, string) = tq_literal_and_str!(1234);
+        let (_, actual) = all_consuming(literal)(&string).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn string() {
+        let (expected, string) = tq_literal_and_str!("hello world\n");
+        let (_, actual) = all_consuming(literal)(&string).unwrap();
+        assert_eq!(expected, actual);
     }
 }


### PR DESCRIPTION
### Added

* Implement support for `FnDecl` with arguments, `FnCall`, and `IdentPath` tokens to `tq!()` macro.
* Add parser tests for literal values and function declarations and calls.

### Changed

* Make `function_decl` parser much more lenient about spaces in and around parentheses.

Apart from the minor function declaration parsing changes, the changes in this pull request should enable the `tq!()` macro to accept function declarations with or without parameters, function calls with or without arguments, and also either of the above with identifier path style names.