### PR TITLE
Make bench test more accurate

### DIFF
--- a/benches/builtin.rs
+++ b/benches/builtin.rs
@@ -14,10 +14,5 @@ fn parse_builtin(b: &mut Criterion) {
     });
 }
 
-criterion_group! {
-    name = benches;
-    config = Criterion::default().sample_size(10);
-    targets = parse_builtin
-}
-
+criterion_group!(benches, parse_builtin);
 criterion_main!(benches);


### PR DESCRIPTION
### Changed

* Remove 10 sample restriction from `builtin` bench test.

This restriction was originally put in place because of how slow `pom` was to benchmark. Now that the parser is written in `nom`, we can lift this limitation because of how fast it is in order to improve benchmark accuracy. The bench test takes about 57 seconds to run on my machine, and thankfully, the results haven't changed too much. In fact, it appears that the parser is actually slightly _faster_ than previous results have indicated, which is nice.

```
parse builtin.tq        time:   [11.319 ms 11.332 ms 11.346 ms]
                        change: [-5.6123% -2.8740% -0.7314%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
```