### PR TITLE
Add assign and logical ops in tq!(), fix expr parsing bug

### DIFF
--- a/src/ast/macros.rs
+++ b/src/ast/macros.rs
@@ -567,7 +567,7 @@ macro_rules! fn_decl {
     };
 
     (@rule ($($expr:tt)+)) => {
-        $crate::sum!($($expr)+)
+        $crate::assign!($($expr)+)
     };
 
     ( $first:tt $($rest:tt)* ) => {{
@@ -576,6 +576,77 @@ macro_rules! fn_decl {
         #[allow(unused_imports)]
         use $crate::ast::tokens::*;
         $crate::fn_decl!(@rule ($first) $($rest)*)
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! assign {
+    // Note that the alt (`//`) operator is separated by a space in this macro because it also
+    // happens to be the comment token in Rust. The `tq_expr_and_str!()` macro will replace these
+    // occurrences with the correct `//` form in the output string.
+    (@rule ($($lhs:tt)+) / /= $($rhs:tt)+) => {{
+        let lhs = $crate::sum!($($lhs)+);
+        let rhs = $crate::sum!($($rhs)+);
+        Expr::AssignOp(BinaryOp::Alt, Box::new(lhs), Box::new(rhs))
+    }};
+
+    (@rule ($($lhs:tt)+) |= $($rhs:tt)+) => {{
+        let lhs = $crate::sum!($($lhs)+);
+        let rhs = $crate::sum!($($rhs)+);
+        Expr::AssignOp(BinaryOp::Pipe, Box::new(lhs), Box::new(rhs))
+    }};
+
+    (@rule ($($lhs:tt)+) += $($rhs:tt)+) => {{
+        let lhs = $crate::sum!($($lhs)+);
+        let rhs = $crate::sum!($($rhs)+);
+        Expr::AssignOp(BinaryOp::Add, Box::new(lhs), Box::new(rhs))
+    }};
+
+    (@rule ($($lhs:tt)+) -= $($rhs:tt)+) => {{
+        let lhs = $crate::sum!($($lhs)+);
+        let rhs = $crate::sum!($($rhs)+);
+        Expr::AssignOp(BinaryOp::Sub, Box::new(lhs), Box::new(rhs))
+    }};
+
+    (@rule ($($lhs:tt)+) *= $($rhs:tt)+) => {{
+        let lhs = $crate::sum!($($lhs)+);
+        let rhs = $crate::sum!($($rhs)+);
+        Expr::AssignOp(BinaryOp::Sub, Box::new(lhs), Box::new(rhs))
+    }};
+
+    (@rule ($($lhs:tt)+) /= $($rhs:tt)+) => {{
+        let lhs = $crate::sum!($($lhs)+);
+        let rhs = $crate::sum!($($rhs)+);
+        Expr::AssignOp(BinaryOp::Sub, Box::new(lhs), Box::new(rhs))
+    }};
+
+    (@rule ($($lhs:tt)+) %= $($rhs:tt)+) => {{
+        let lhs = $crate::sum!($($lhs)+);
+        let rhs = $crate::sum!($($rhs)+);
+        Expr::AssignOp(BinaryOp::Sub, Box::new(lhs), Box::new(rhs))
+    }};
+
+    (@rule ($($lhs:tt)+) = $($rhs:tt)+) => {{
+        let lhs = $crate::sum!($($lhs)+);
+        let rhs = $crate::sum!($($rhs)+);
+        Expr::Assign(Box::new(lhs), Box::new(rhs))
+    }};
+
+    (@rule ($($prev:tt)*) $next:tt $($rest:tt)*) => {
+        $crate::assign!(@rule ($($prev)* $next) $($rest)*)
+    };
+
+    (@rule ($($expr:tt)+)) => {
+        $crate::sum!($($expr)+)
+    };
+
+    ( $first:tt $($rest:tt)* ) => {{
+        #[allow(unused_imports)]
+        use $crate::ast::*;
+        #[allow(unused_imports)]
+        use $crate::ast::tokens::*;
+        $crate::assign!(@rule ($first) $($rest)*)
     }};
 }
 

--- a/src/ast/macros.rs
+++ b/src/ast/macros.rs
@@ -586,55 +586,87 @@ macro_rules! assign {
     // happens to be the comment token in Rust. The `tq_expr_and_str!()` macro will replace these
     // occurrences with the correct `//` form in the output string.
     (@rule ($($lhs:tt)+) / /= $($rhs:tt)+) => {{
-        let lhs = $crate::sum!($($lhs)+);
-        let rhs = $crate::sum!($($rhs)+);
+        let lhs = $crate::logical!($($lhs)+);
+        let rhs = $crate::logical!($($rhs)+);
         Expr::AssignOp(BinaryOp::Alt, Box::new(lhs), Box::new(rhs))
     }};
 
     (@rule ($($lhs:tt)+) |= $($rhs:tt)+) => {{
-        let lhs = $crate::sum!($($lhs)+);
-        let rhs = $crate::sum!($($rhs)+);
+        let lhs = $crate::logical!($($lhs)+);
+        let rhs = $crate::logical!($($rhs)+);
         Expr::AssignOp(BinaryOp::Pipe, Box::new(lhs), Box::new(rhs))
     }};
 
     (@rule ($($lhs:tt)+) += $($rhs:tt)+) => {{
-        let lhs = $crate::sum!($($lhs)+);
-        let rhs = $crate::sum!($($rhs)+);
+        let lhs = $crate::logical!($($lhs)+);
+        let rhs = $crate::logical!($($rhs)+);
         Expr::AssignOp(BinaryOp::Add, Box::new(lhs), Box::new(rhs))
     }};
 
     (@rule ($($lhs:tt)+) -= $($rhs:tt)+) => {{
-        let lhs = $crate::sum!($($lhs)+);
-        let rhs = $crate::sum!($($rhs)+);
+        let lhs = $crate::logical!($($lhs)+);
+        let rhs = $crate::logical!($($rhs)+);
         Expr::AssignOp(BinaryOp::Sub, Box::new(lhs), Box::new(rhs))
     }};
 
     (@rule ($($lhs:tt)+) *= $($rhs:tt)+) => {{
-        let lhs = $crate::sum!($($lhs)+);
-        let rhs = $crate::sum!($($rhs)+);
+        let lhs = $crate::logical!($($lhs)+);
+        let rhs = $crate::logical!($($rhs)+);
         Expr::AssignOp(BinaryOp::Sub, Box::new(lhs), Box::new(rhs))
     }};
 
     (@rule ($($lhs:tt)+) /= $($rhs:tt)+) => {{
-        let lhs = $crate::sum!($($lhs)+);
-        let rhs = $crate::sum!($($rhs)+);
+        let lhs = $crate::logical!($($lhs)+);
+        let rhs = $crate::logical!($($rhs)+);
         Expr::AssignOp(BinaryOp::Sub, Box::new(lhs), Box::new(rhs))
     }};
 
     (@rule ($($lhs:tt)+) %= $($rhs:tt)+) => {{
-        let lhs = $crate::sum!($($lhs)+);
-        let rhs = $crate::sum!($($rhs)+);
+        let lhs = $crate::logical!($($lhs)+);
+        let rhs = $crate::logical!($($rhs)+);
         Expr::AssignOp(BinaryOp::Sub, Box::new(lhs), Box::new(rhs))
     }};
 
     (@rule ($($lhs:tt)+) = $($rhs:tt)+) => {{
-        let lhs = $crate::sum!($($lhs)+);
-        let rhs = $crate::sum!($($rhs)+);
+        let lhs = $crate::logical!($($lhs)+);
+        let rhs = $crate::logical!($($rhs)+);
         Expr::Assign(Box::new(lhs), Box::new(rhs))
     }};
 
     (@rule ($($prev:tt)*) $next:tt $($rest:tt)*) => {
         $crate::assign!(@rule ($($prev)* $next) $($rest)*)
+    };
+
+    (@rule ($($expr:tt)+)) => {
+        $crate::logical!($($expr)+)
+    };
+
+    ( $first:tt $($rest:tt)* ) => {{
+        #[allow(unused_imports)]
+        use $crate::ast::*;
+        #[allow(unused_imports)]
+        use $crate::ast::tokens::*;
+        $crate::assign!(@rule ($first) $($rest)*)
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! logical {
+    (@rule ($($lhs:tt)+) and $($rhs:tt)+) => {{
+        let lhs = $crate::sum!($($lhs)+);
+        let rhs = $crate::logical!($($rhs)+);
+        Expr::Binary(BinaryOp::And, Box::new(lhs), Box::new(rhs))
+    }};
+
+    (@rule ($($lhs:tt)+) or $($rhs:tt)+) => {{
+        let lhs = $crate::sum!($($lhs)+);
+        let rhs = $crate::logical!($($rhs)+);
+        Expr::Binary(BinaryOp::Or, Box::new(lhs), Box::new(rhs))
+    }};
+
+    (@rule ($($prev:tt)*) $next:tt $($rest:tt)*) => {
+        $crate::logical!(@rule ($($prev)* $next) $($rest)*)
     };
 
     (@rule ($($expr:tt)+)) => {
@@ -646,7 +678,7 @@ macro_rules! assign {
         use $crate::ast::*;
         #[allow(unused_imports)]
         use $crate::ast::tokens::*;
-        $crate::assign!(@rule ($first) $($rest)*)
+        $crate::logical!(@rule ($first) $($rest)*)
     }};
 }
 

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -88,7 +88,7 @@ fn assign(input: &str) -> IResult<&str, Expr> {
     let add = map(char('+'), |_| BinaryOp::Add);
     let sub = map(char('-'), |_| BinaryOp::Sub);
     let mul = map(char('*'), |_| BinaryOp::Mul);
-    let div = map(char('*'), |_| BinaryOp::Div);
+    let div = map(char('/'), |_| BinaryOp::Div);
     let rem = map(char('%'), |_| BinaryOp::Mod);
     let arithmetic = alt((add, sub, mul, div, rem));
 


### PR DESCRIPTION
### Added

* Implement support for assign operators in `tq!()` macro.
* Implement support for logical operators in `tq!()` macro.

### Changed

* Evaluate `lhs` with lower precedence rule, update `tq!()` doc comment.

### Fixed

* Fix parsing of `/=` operator in `expr.rs`.