### PR TITLE
Add constructors, labels, complex patterns in tq!() macro

### DIFF
--- a/src/ast/macros.rs
+++ b/src/ast/macros.rs
@@ -610,6 +610,12 @@ macro_rules! pipe {
         Expr::Binding(Box::new(bind), Box::new($crate::pipe!($($rest)+)))
     }};
 
+    (@rule (label $dollar:tt $var:ident) | $($rest:tt)+) => {{
+        let label = Expr::Label(Label::from(concat!("$", stringify!($var))));
+        let expr = $crate::pipe!($($rest)+);
+        Expr::Binary(BinaryOp::Pipe, Box::new(label), Box::new(expr))
+    }};
+
     (@rule ($($lhs:tt)+) | $($rhs:tt)+) => {{
         let lhs = $crate::chain!($($lhs)+);
         let rhs = $crate::pipe!($($rhs)+);

--- a/src/ast/macros.rs
+++ b/src/ast/macros.rs
@@ -215,6 +215,96 @@ macro_rules! tq_table_key {
 
 #[doc(hidden)]
 #[macro_export]
+macro_rules! tq_table_value {
+    ( ($($expr:tt)+) ) => {
+        $crate::tq_expr!($($expr)+)
+    };
+
+    ( -$($expr:tt)+ ) => {
+        Expr::Unary(UnaryOp::Neg, Box::new($crate::tq_table_value!($($expr)+)))
+    };
+
+    (@pipe ($($term:tt)+) | $($rest:tt)+) => {{
+        let lhs = $crate::term!($($term)+);
+        let rhs = $crate::tq_table_value!($($rest)+);
+        Expr::Binary(BinaryOp::Pipe, Box::new(lhs), Box::new(rhs))
+    }};
+
+    (@pipe ($($term:tt)+)) => {
+        $crate::term!($($term)+)
+    };
+
+    (@pipe ($($term:tt)+) $next:tt $($rest:tt)*) => {
+        $crate::tq_table_value!(@pipe ($($term)+ $next) $($rest)*)
+    };
+
+    ( $first:tt $($rest:tt)* ) => {{
+        #[allow(unused_imports)]
+        use $crate::ast::*;
+        #[allow(unused_imports)]
+        use $crate::ast::tokens::*;
+        $crate::tq_table_value!(@pipe ($first) $($rest)*)
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! tq_construct {
+    ( [ ] ) => {
+        Expr::Array(None)
+    };
+
+    ( [ $($expr:tt)+ ] ) => {
+        Expr::Array(Some(Box::new($crate::tq_expr!($($expr)+))))
+    };
+
+    ( { } ) => {
+        Expr::Table(Vec::new())
+    };
+
+    ( { $($members:tt)+ } ) => {
+        Expr::Table($crate::tq_construct!(@table $($members)+).collect())
+    };
+
+    (@member ($dollar:tt $var:ident = $($value:tt)+) , $($rest:tt)+) => {{
+        let member = ($crate::tq_table_key!($dollar$var), $crate::tq_table_value!($($value)+));
+        ::std::iter::once(member).chain($crate::tq_construct!(@table $($rest)+))
+    }};
+
+    (@member ($key:tt = $($value:tt)+) , $($rest:tt)+) => {{
+        let member = ($crate::tq_table_key!($key), $crate::tq_table_value!($($value)+));
+        ::std::iter::once(member).chain($crate::tq_construct!(@table $($rest)+))
+    }};
+
+    (@member ($dollar:tt $var:ident = $($value:tt)+)) => {
+        ::std::iter::once((
+            $crate::tq_table_key!($dollar$var),
+            $crate::tq_table_value!($($value)+),
+        ))
+    };
+
+    (@member ($key:tt = $($value:tt)+)) => {
+        ::std::iter::once((
+            $crate::tq_table_key!($key),
+            $crate::tq_table_value!($($value)+),
+        ))
+    };
+
+    (@member ($($members:tt)+) $next:tt $($rest:tt)*) => {
+        $crate::tq_construct!(@member ($($members)+ $next) $($rest)*)
+    };
+
+    (@table $first:tt $($rest:tt)* ) => {{
+        #[allow(unused_imports)]
+        use $crate::ast::*;
+        #[allow(unused_imports)]
+        use $crate::ast::tokens::*;
+        $crate::tq_construct!(@member ($first) $($rest)*)
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
 macro_rules! tq_pattern {
     ( ($($pat:tt)+) ) => {
         $crate::tq_pattern!($($pat)+)
@@ -226,22 +316,49 @@ macro_rules! tq_pattern {
         ])
     };
 
-    ( { $($assign:tt)+ } ) => {
-        ExprPattern::Table(vec![
-            $crate::tq_pattern!(@assign $($assign)+)
-        ])
-    };
-
-    (@assign $key:tt = $($value:tt)+) => {
-        (
-            $crate::tq_table_key!($key),
-            $crate::tq_pattern!($($value)+),
-        )
+    ( { $($members:tt)+ } ) => {
+        ExprPattern::Table($crate::tq_pattern!(@table $($members)+).collect())
     };
 
     ( $dollar:tt $var:ident ) => {
         ExprPattern::Variable($crate::tq_token!($dollar$var))
     };
+
+    (@member ($dollar:tt $var:ident = $($value:tt)+) , $($rest:tt)+) => {{
+        let member = ($crate::tq_table_key!($dollar$var), $crate::tq_pattern!($($value)+));
+        ::std::iter::once(member).chain($crate::tq_pattern!(@table $($rest)+))
+    }};
+
+    (@member ($key:tt = $($value:tt)+) , $($rest:tt)+) => {{
+        let member = ($crate::tq_table_key!($key), $crate::tq_pattern!($($value)+));
+        ::std::iter::once(member).chain($crate::tq_pattern!(@table $($rest)+))
+    }};
+
+    (@member ($dollar:tt $var:ident = $($value:tt)+)) => {
+        ::std::iter::once((
+            $crate::tq_table_key!($dollar$var),
+            $crate::tq_pattern!($($value)+),
+        ))
+    };
+
+    (@member ($key:tt = $($value:tt)+)) => {
+        ::std::iter::once((
+            $crate::tq_table_key!($key),
+            $crate::tq_pattern!($($value)+),
+        ))
+    };
+
+    (@member ($($members:tt)+) $next:tt $($rest:tt)*) => {
+        $crate::tq_pattern!(@member ($($members)+ $next) $($rest)*)
+    };
+
+    (@table $first:tt $($rest:tt)* ) => {{
+        #[allow(unused_imports)]
+        use $crate::ast::*;
+        #[allow(unused_imports)]
+        use $crate::ast::tokens::*;
+        $crate::tq_pattern!(@member ($first) $($rest)*)
+    }};
 }
 
 #[doc(hidden)]
@@ -812,41 +929,49 @@ macro_rules! unary {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! term {
-    (($($expr:tt)+)) => {{
+    (($($expr:tt)+)) => {
         Expr::Paren(Box::new($crate::tq_expr!($($expr)+)))
-    }};
+    };
 
-    (..) => {{
+    ({ $($members:tt)* }) => {
+        $crate::tq_construct!({ $($members)* })
+    };
+
+    ([ $($expr:tt)* ]) => {
+        $crate::tq_construct!([ $($expr)* ])
+    };
+
+    (..) => {
         Expr::Filter(Box::new($crate::tq_filter!(..)))
-    }};
+    };
 
-    (.$($path:tt)*) => {{
+    (.$($path:tt)*) => {
         Expr::Filter(Box::new($crate::tq_filter!(.$($path)*)))
-    }};
+    };
 
-    ($dollar:tt $var:ident $($path:tt)+) => {{
+    ($dollar:tt $var:ident $($path:tt)+) => {
         Expr::Filter(Box::new($crate::tq_filter!($dollar$var$($path)*)))
-    }};
+    };
 
-    ($dollar:tt $var:ident) => {{
+    ($dollar:tt $var:ident) => {
         Expr::Variable($crate::tq_token!($dollar$var))
-    }};
+    };
 
-    (false) => {{
+    (false) => {
         Expr::Literal($crate::tq_token!(false))
-    }};
+    };
 
-    (true) => {{
+    (true) => {
         Expr::Literal($crate::tq_token!(true))
-    }};
+    };
 
-    (inf) => {{
+    (inf) => {
         Expr::Literal($crate::tq_token!(inf))
-    }};
+    };
 
-    (nan) => {{
+    (nan) => {
         Expr::Literal($crate::tq_token!(nan))
-    }};
+    };
 
     ($($fn_call:ident)::+) => {{
         let path = $crate::tq_token!(::$($fn_call)::+);
@@ -859,7 +984,7 @@ macro_rules! term {
         Expr::FnCall(ExprFnCall::new(path, args))
     }};
 
-    ($literal:expr) => {{
+    ($literal:expr) => {
         Expr::Literal($crate::tq_token!($literal))
-    }};
+    };
 }

--- a/src/parser/expr/construct.rs
+++ b/src/parser/expr/construct.rs
@@ -56,3 +56,33 @@ fn table_value(input: &str) -> IResult<&str, Expr> {
     let paren = delimited(pair(char('('), tokens::space), table_value, char(')'));
     alt((paren, neg, pipe))(input)
 }
+
+#[cfg(test)]
+mod tests {
+    use nom::combinator::all_consuming;
+
+    use super::*;
+    use crate::tq_expr_and_str;
+
+    #[test]
+    fn array() {
+        let (expected, string) = tq_expr_and_str!([]);
+        let (_, actual) = all_consuming(construct)(&string).unwrap();
+        assert_eq!(expected, actual);
+
+        let (expected, string) = tq_expr_and_str!([.foo.bar[]]);
+        let (_, actual) = all_consuming(construct)(&string).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn table() {
+        let (expected, string) = tq_expr_and_str!({});
+        let (_, actual) = all_consuming(construct)(&string).unwrap();
+        assert_eq!(expected, actual);
+
+        let (expected, string) = tq_expr_and_str!({ one = 1, two = -func(12), three = foo | bar });
+        let (_, actual) = all_consuming(construct)(&string).unwrap();
+        assert_eq!(expected, actual);
+    }
+}


### PR DESCRIPTION
### Added

* Implement array and table constructors support in `tq!()` macro.
* Implement label declaration support in `tq!()` macro.
* Add array and table constructor parse tests.

### Changed

* Allow table patterns with multiple rows in `tq_pattern!()`.