### PR TITLE
Optimize assign op expression parsing

### DIFF
--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -81,18 +81,15 @@ fn label(input: &str) -> IResult<&str, Expr> {
 }
 
 fn assign(input: &str) -> IResult<&str, Expr> {
-    let alt_ = map(tag("//"), |_| BinaryOp::Alt);
     let pipe = map(char('|'), |_| BinaryOp::Pipe);
-    let stream = alt((alt_, pipe));
-
     let add = map(char('+'), |_| BinaryOp::Add);
     let sub = map(char('-'), |_| BinaryOp::Sub);
     let mul = map(char('*'), |_| BinaryOp::Mul);
+    let alt_ = map(tag("//"), |_| BinaryOp::Alt);
     let div = map(char('/'), |_| BinaryOp::Div);
     let rem = map(char('%'), |_| BinaryOp::Mod);
-    let arithmetic = alt((add, sub, mul, div, rem));
 
-    let op = terminated(opt(alt((stream, arithmetic))), char('='));
+    let op = terminated(opt(alt((pipe, add, sub, mul, alt_, div, rem))), char('='));
     let expr = pair(logical, opt(pair(terminated(op, tokens::space), logical)));
     map(expr, |(expr, assign)| match assign {
         Some((Some(op), value)) => Expr::AssignOp(op, Box::new(expr), Box::new(value)),


### PR DESCRIPTION
### Fixed

* Optimize assign op expression parsing.

This should improve the performance of the fix introduced in #43, as evidenced by the benchmark results shown below:

```
parse builtin.tq        time:   [11.392 ms 11.459 ms 11.537 ms]
                        change: [-9.0442% -5.3849% -2.6330%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) high mild
  9 (9.00%) high severe
```

This should bring performance back down to parsing speeds prior to #42:

```
parse builtin.tq        time:   [11.355 ms 11.380 ms 11.409 ms]
                        change: [-0.6818% +0.6074% +2.1555%] (p = 0.46 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe
```