### PR TITLE
Remove unused tokens::space check for label exprs

### DIFF
--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -71,7 +71,7 @@ fn binding(input: &str) -> IResult<&str, Expr> {
 
 fn label(input: &str) -> IResult<&str, Expr> {
     let label = map(label_decl, Expr::Label);
-    let label = terminated(label, tuple((tokens::space, char('|'), tokens::space)));
+    let label = terminated(label, pair(char('|'), tokens::space));
     let expr = pair(many0(label), assign);
     map(expr, |(decls, expr)| {
         decls.into_iter().rev().fold(expr, |expr, label| {


### PR DESCRIPTION
### Removed

* Remove unused `tokens::space` check for label expressions.

This change has a slight improvement in parsing performance, as indicated by the benchmark results below:

```
parse builtin.tq        time:   [11.442 ms 11.465 ms 11.493 ms]
                        change: [-3.6899% -2.4008% -1.2458%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe
```