### PR TITLE
Fix _flatten function in builtin.tq

### DIFF
--- a/builtin.tq
+++ b/builtin.tq
@@ -49,7 +49,7 @@ def join($x): reduce .[] as $i (null;
             (if .==null then "" else .+$x end) +
             ($i | if type=="boolean" or type=="number" then tostring else .//"" end)
         ) // "";
-def _flatten($x): reduce .[] as $i ([]; if $i | type == "array" and $x != 0 then . + ($i | _flatten($x-1)) else . + [$i] end);
+def _flatten($x): reduce .[] as $i ([]; if $i | type == "array" and $x != 0 then . + ($i | _flatten($x - 1)) else . + [$i] end);
 def flatten($x): if $x < 0 then error("flatten depth must not be negative") else _flatten($x) end;
 def flatten: _flatten(-1);
 def range($x): range(0;$x);


### PR DESCRIPTION
### Fixed

* Replace `$x-1` with `$x - 1` in `builtin.tq` because the former is considered a valid `tq` identifier.

This PR provides a fix similar to #46.